### PR TITLE
Use stable nvidia container toolkit

### DIFF
--- a/pkg/nvkind/node.go
+++ b/pkg/nvkind/node.go
@@ -36,7 +36,7 @@ func (n *Node) InstallContainerToolkit() error {
 		apt-get update
 		apt-get install -y gpg
 		curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-		curl -s -L https://nvidia.github.io/libnvidia-container/experimental/deb/nvidia-container-toolkit.list | \
+		curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
 			sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
 				tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 		apt-get update

--- a/shell/common.sh
+++ b/shell/common.sh
@@ -57,7 +57,7 @@ function install_container_toolkit() {
 		apt-get update
 		apt-get install -y gpg
 	    curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | gpg --dearmor -o /usr/share/keyrings/nvidia-container-toolkit-keyring.gpg
-		curl -s -L https://nvidia.github.io/libnvidia-container/experimental/deb/nvidia-container-toolkit.list | \
+		curl -s -L https://nvidia.github.io/libnvidia-container/stable/deb/nvidia-container-toolkit.list | \
 			sed 's#deb https://#deb [signed-by=/usr/share/keyrings/nvidia-container-toolkit-keyring.gpg] https://#g' | \
 				tee /etc/apt/sources.list.d/nvidia-container-toolkit.list
 		apt-get update


### PR DESCRIPTION
This fixes an issue with the bitnami postgres helm chart.  I noticed that simply installing the experimental package caused postgres to fail. I wasn't able to figure out why :disappointed: 

Steps to reproduce the issue:

```bash
nvkind cluster create
helm install pg oci://registry-1.docker.io/bitnamicharts/postgresql
watch kubectl get pods
# wait 5 minutes to see postgres pod restart / crashloopbackoff
```

I'm not sure if this is the correct way to fix this, but it may at least save others some time.